### PR TITLE
fixed some packaging issues for 6L38

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -88,6 +88,7 @@ deb: dist
 		debian/rules \
 		$(DEBSOURCEDIR)/debian && \
 	cd $(DEBSOURCEDIR) && \
+	DEB_BUILD_MAINT_OPTIONS=hardening=-format \
 	$(DEBUILD) -rfakeroot -D -us -uc; \
 	cd $(srcdir); \
 	rm --force $(DEBSOURCEPKG); \

--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@ AC_CONFIG_SRCDIR(src/main.c)
 # Tell where to put the libtool macros
 AC_CONFIG_MACRO_DIR([m4])
 # Initialize automake; pkglibexecdir and silent rules introduced in 1.11
-AM_INIT_AUTOMAKE([1.11 -Wall])
+AM_INIT_AUTOMAKE([1.11 -Wall subdir-objects])
 # Configure with --enable-silent-rules to cut down on clutter
 AM_SILENT_RULES([yes])
 # Allow "AM_GST_ELEMENT_CHECK" for building without GStreamer development files

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -323,7 +323,7 @@ SKIP_PATHS = \
 	/story/old-materials-file \
 	/story/renames-materials-file \
 	$(NULL)
-LOG_COMPILER = gtester -k --verbose $(addprefix -s=,$(SKIP_PATHS))
+LOG_COMPILER = gtester -k --verbose "`echo $(SKIP_PATHS) | sed 's/\</-s=/g'`"
 EXTRA_DIST += \
 	tests/commands.rec \
 	tests/Hereafter.inform/Settings.plist \

--- a/src/cBlorb/Makefile.am
+++ b/src/cBlorb/Makefile.am
@@ -83,7 +83,7 @@ endif
 
 EXTRA_DIST = $(cblorbmaterials)
 
-ABSDISTDIR = $(abspath $(distdir))
+ABSDISTDIR = `(cd $(distdir) && pwd)`
 dist-hook:
 	$(MKDIR_P) --mode=u+w $(distdir)/Preliminaries $(distdir)/Chapter\ 1 \
 		$(distdir)/Chapter\ 2 $(distdir)/Chapter\ 3 $(distdir)/Woven \

--- a/src/inwebc/Makefile.am
+++ b/src/inwebc/Makefile.am
@@ -144,7 +144,7 @@ EXTRA_DIST = $(inwebmaterials)
 # Also: why should the distdir be unwritable?!
 #
 # Also: why is distdir sometimes an absolute path and sometimes relative?
-ABSDISTDIR = $(abspath $(distdir))
+ABSDISTDIR = `(cd $(distdir) && pwd)`
 dist-hook:
 	$(MKDIR_P) --mode=u+w \
 		$(distdir)/Preliminaries \


### PR DESCRIPTION
This fixes a bunch of little nits: removes GNUMake dependencies from Makefile.ams, removes some other Makefile.am warnings by setting subdir-objects, sets DEB_BUILD_MAINT_OPTIONS to hardening=-format to suppress some more warnings. Hope it helps.

Thanks huge for gnome-inform7.
