### PR TITLE
Update Inform compiler to 10.1.2

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -160,8 +160,8 @@ jobs:
 
       - name: upgrade-meson
         run: |
-          curl -O http://ftp.osuosl.org/pub/ubuntu/pool/universe/m/meson/meson_0.57.0+really0.56.2-0.1_all.deb
-          sudo dpkg -i meson_0.57.0+really0.56.2-0.1_all.deb
+          curl -O http://ftp.osuosl.org/pub/ubuntu/pool/universe/m/meson/meson_0.61.2-1_all.deb
+          sudo dpkg -i meson_0.61.2-1_all.deb
 
       - name: Checkout Inform IDE
         uses: actions/checkout@v3

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -5,9 +5,12 @@ name: Build packages
     branches: [main]
 
 env:
-  inweb_commit: 2aca05e8e28c6385ade2a0637d9a79adbede9bb5
-  intest_commit: 06c8a4f57f104fa12abcf478371748b5bd829c7b
-  inform_commit: 7f7deec532d7c92ce14c2ba161f1fa6ae0677a85
+  inweb_tag: v7.2.0
+  intest_tag: v2.1.0
+  inform_tag: v10.1.2
+  inweb_short_sha: 60735b4
+  intest_short_sha: 45b6278
+  inform_short_sha: 1f43d73
   version: '2.0.0'
   QA_RPATHS: 1
   DEB_BUILD_MAINT_OPTIONS: hardening=-format
@@ -61,21 +64,21 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: ganelson/inweb
-          ref: 2aca05e8e28c6385ade2a0637d9a79adbede9bb5
+          ref: v7.2.0
           path: inweb
 
       - name: Checkout Intest
         uses: actions/checkout@v3
         with:
           repository: ganelson/intest
-          ref: 06c8a4f57f104fa12abcf478371748b5bd829c7b
+          ref: v2.1.0
           path: intest
 
       - name: Checkout Inform
         uses: actions/checkout@v3
         with:
           repository: ganelson/inform
-          ref: 7f7deec532d7c92ce14c2ba161f1fa6ae0677a85
+          ref: v10.1.2
           path: inform
 
       - name: Checkout Inform IDE
@@ -104,14 +107,17 @@ jobs:
         run: |
           mkdir -p /github/home/rpmbuild/SOURCES/
           cd inweb
-          git archive -o "/github/home/rpmbuild/SOURCES/$inweb_commit.zip" \
-            --prefix="inweb-$inweb_commit/" $inweb_commit
+          git archive -o \
+            "/github/home/rpmbuild/SOURCES/ganelson-inweb-$inweb_tag-0-g$inweb_short_sha.tar.gz" \
+            --prefix="ganelson-inweb-$inweb_short_sha/" $inweb_short_sha
           cd ../intest
-          git archive -o  "/github/home/rpmbuild/SOURCES/$intest_commit.zip" \
-            --prefix="intest-$intest_commit/" $intest_commit
+          git archive -o \
+            "/github/home/rpmbuild/SOURCES/ganelson-intest-$intest_tag-0-g$intest_short_sha.tar.gz" \
+            --prefix="ganelson-intest-$intest_short_sha/" $intest_short_sha
           cd ../inform
-          git archive -o "/github/home/rpmbuild/SOURCES/$inform_commit.zip" \
-            --prefix="inform-$inform_commit/" $inform_commit
+          git archive -o \
+            "/github/home/rpmbuild/SOURCES/ganelson-inform-$inform_tag-0-g$inform_short_sha.tar.gz" \
+            --prefix="ganelson-inform-$inform_short_sha/" $inform_short_sha
           cd ..
           tar cJf "/github/home/rpmbuild/SOURCES/inform7-ide-$version.tar.xz" \
             --xform "s:^inform7-ide/:inform7-ide-$version/:" inform7-ide
@@ -164,21 +170,21 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: ganelson/inweb
-          ref: 2aca05e8e28c6385ade2a0637d9a79adbede9bb5
+          ref: v7.2.0
           path: inweb
 
       - name: Checkout Intest
         uses: actions/checkout@v3
         with:
           repository: ganelson/intest
-          ref: 06c8a4f57f104fa12abcf478371748b5bd829c7b
+          ref: v2.1.0
           path: intest
 
       - name: Checkout Inform
         uses: actions/checkout@v3
         with:
           repository: ganelson/inform
-          ref: 7f7deec532d7c92ce14c2ba161f1fa6ae0677a85
+          ref: v10.1.2
           path: inform
 
       - name: Download subprojects
@@ -196,13 +202,13 @@ jobs:
         run: |
           cd inweb
           git archive -o "../../inform7-ide_$version.orig-inweb.tar.gz" \
-            $inweb_commit
+            $inweb_short_sha
           cd ../intest
           git archive -o  "../../inform7-ide_$version.orig-intest.tar.gz" \
-            $intest_commit
+            $intest_short_sha
           cd ../inform
           git archive -o "../../inform7-ide_$version.orig-inform.tar.gz" \
-            $inform_commit
+            $inform_short_sha
           cd ..
           tar cJf "../inform7-ide_$version.orig.tar.xz" \
             --xform "s:^:inform7-ide-$version/:" \

--- a/build-aux/build-deb.sh
+++ b/build-aux/build-deb.sh
@@ -8,9 +8,9 @@ if test -z "$builddir"; then
     exit 1
 fi
 
-inweb_commit=2aca05e8e28c6385ade2a0637d9a79adbede9bb5
-intest_commit=06c8a4f57f104fa12abcf478371748b5bd829c7b
-inform_commit=7f7deec532d7c92ce14c2ba161f1fa6ae0677a85
+inweb_ref=v7.2.0
+intest_ref=v2.1.0
+inform_ref=v10.1.2
 
 package=$(meson introspect "$builddir" --projectinfo | jq -r .descriptive_name)
 version=$(meson introspect "$builddir" --projectinfo | jq -r .version)
@@ -38,7 +38,7 @@ cd "$debsourcedir"
 # component, or dpkg-unpack will not unpack them correctly.
 
 if test ! -e "../$package_$version.orig-inweb.tar.gz"; then
-    wget "https://api.github.com/repos/ganelson/inweb/tarball/$inweb_commit" \
+    wget "https://api.github.com/repos/ganelson/inweb/tarball/$inweb_ref" \
         -O inweb.tar.gz
     mkdir inweb
     tar xzf inweb.tar.gz -C inweb --strip-components=1
@@ -46,7 +46,7 @@ if test ! -e "../$package_$version.orig-inweb.tar.gz"; then
     rm inweb.tar.gz
 fi
 if test ! -e "../$package_$version.orig-intest.tar.gz"; then
-    wget "https://api.github.com/repos/ganelson/intest/tarball/$intest_commit" \
+    wget "https://api.github.com/repos/ganelson/intest/tarball/$intest_ref" \
         -O intest.tar.gz
     mkdir intest
     tar xzf intest.tar.gz -C intest --strip-components=1
@@ -54,7 +54,7 @@ if test ! -e "../$package_$version.orig-intest.tar.gz"; then
     rm intest.tar.gz
 fi
 if test ! -e "../$package_$version.orig-inform.tar.gz"; then
-    wget "https://api.github.com/repos/ganelson/inform/tarball/$inform_commit" \
+    wget "https://api.github.com/repos/ganelson/inform/tarball/$inform_ref" \
         -O inform.tar.gz
     mkdir inform
     tar xzf inform.tar.gz -C inform --strip-components=1

--- a/build-aux/build-rpm.sh
+++ b/build-aux/build-rpm.sh
@@ -6,9 +6,9 @@ if test -z "$builddir"; then
     exit 1
 fi
 
-inweb_commit=2aca05e8e28c6385ade2a0637d9a79adbede9bb5
-intest_commit=06c8a4f57f104fa12abcf478371748b5bd829c7b
-inform_commit=7f7deec532d7c92ce14c2ba161f1fa6ae0677a85
+inweb_ref=v7.2.0
+intest_ref=v2.1.0
+inform_ref=v10.1.2
 
 package=$(meson introspect "$builddir" --projectinfo | jq -r .descriptive_name)
 version=$(meson introspect "$builddir" --projectinfo | jq -r .version)
@@ -24,17 +24,17 @@ sourcedir=$(rpm --eval %_sourcedir)
 srcrpmdir=$(rpm --eval %_srcrpmdir)
 arch=$(rpm --eval %_target_cpu)
 
-if test ! -e "$sourcedir/$inweb_commit.zip"; then
-    wget "https://github.com/ganelson/inweb/archive/$inweb_commit.zip" \
-        -P "$sourcedir"
+if ! ls "$sourcedir"/ganelson-inweb-$inweb_ref-*.tar.gz >/dev/null; then
+    wget "https://api.github.com/repos/ganelson/inweb/tarball/$inweb_ref" \
+        --content-disposition -P "$sourcedir"
 fi
-if test ! -e "$sourcedir/$intest_commit.zip"; then
-    wget "https://github.com/ganelson/intest/archive/$intest_commit.zip" \
-        -P "$sourcedir"
+if ! ls "$sourcedir"/ganelson-intest-$intest_ref-*.tar.gz >/dev/null; then
+    wget "https://api.github.com/repos/ganelson/intest/tarball/$intest_ref" \
+        --content-disposition -P "$sourcedir"
 fi
-if test ! -e "$sourcedir/$inform_commit.zip"; then
-    wget "https://github.com/ganelson/inform/archive/$inform_commit.zip" \
-        -P "$sourcedir"
+if ! ls "$sourcedir"/ganelson-inform-$inform_ref-*.tar.gz >/dev/null; then
+    wget "https://api.github.com/repos/ganelson/inform/tarball/$inform_ref" \
+        --content-disposition -P "$sourcedir"
 fi
 
 cp "$dist_tarball" "$sourcedir/"

--- a/build-aux/com.inform7.IDE.yml
+++ b/build-aux/com.inform7.IDE.yml
@@ -188,15 +188,18 @@ modules:
     sources:
       - type: git
         url: https://github.com/ganelson/inweb.git
-        commit: 2aca05e8e28c6385ade2a0637d9a79adbede9bb5
+        tag: v7.2.0
+        commit: 60735b4c46de5ba8bd6ceca61b7266a76d76af35
         dest: inweb
       - type: git
         url: https://github.com/ganelson/intest.git
-        commit: 06c8a4f57f104fa12abcf478371748b5bd829c7b
+        tag: v2.1.0
+        commit: 45b6278c633a7fa20395d17b87e91dcd3049052a
         dest: intest
       - type: git
         url: https://github.com/ganelson/inform.git
-        commit: 7f7deec532d7c92ce14c2ba161f1fa6ae0677a85
+        tag: v10.1.2
+        commit: 1f43d739eb5afa81241fed0abf39bb3ce0332dde
         dest: inform
       - type: file
         path: flatpak-integration-settings.mk

--- a/build-aux/flatpak-integration-settings.mk
+++ b/build-aux/flatpak-integration-settings.mk
@@ -10,6 +10,7 @@ BUILTINCOMPS = /app/tmp/intools
 INTERNAL = /app/tmp/data
 BUILTINHTML = /app/tmp/inform
 BUILTINHTMLINNER = /app/tmp/inform/en
+ADVICEHTML = /app/tmp/inform/en
 
 # Names of the tools and options are the same as in the regular Linux build,
 # except we have an Indoc profile that installs to /app/tmp
@@ -20,4 +21,5 @@ INFORM7NAME = inform7
 INTESTNAME = intest
 
 INDOCOPTS = gnome_flatpak_app
+HTMLPLATFORM = linux
 INRTPSOPTS = -font

--- a/build-aux/make-integration-settings.mk
+++ b/build-aux/make-integration-settings.mk
@@ -14,6 +14,7 @@ BUILTINCOMPS = ../inform7-ide/intools
 INTERNAL = ../inform7-ide/data
 BUILTINHTML = ../inform7-ide/src/inform
 BUILTINHTMLINNER = ../inform7-ide/src/inform/en
+ADVICEHTML = ../inform7-ide/src/inform/en
 
 # Various executables are copied into the BUILTINCOMPS folder, but their
 # filenames when copied there have sometimes differed between platforms.
@@ -26,6 +27,7 @@ INTESTNAME = intest
 # Indoc options for generating the inside-the-application documentation:
 
 INDOCOPTS = gnome_app
+HTMLPLATFORM = linux
 
 # For reasons to do with CSS, the following should be "-nofont" for Windows:
 

--- a/inform7-ide.spec
+++ b/inform7-ide.spec
@@ -5,14 +5,17 @@ Release: 1%{?dist}
 URL: http://inform7.com/
 License: GPLv3
 
-%define inweb_commit 2aca05e8e28c6385ade2a0637d9a79adbede9bb5
-%define intest_commit 06c8a4f57f104fa12abcf478371748b5bd829c7b
-%define inform_commit 7f7deec532d7c92ce14c2ba161f1fa6ae0677a85
+%define inweb_ref v7.2.0
+%define intest_ref v2.1.0
+%define inform_ref v10.1.2
+%define inweb_short_sha 60735b4
+%define intest_short_sha 45b6278
+%define inform_short_sha 1f43d73
 
 Source0: https://github.com/ptomato/inform7-ide/releases/download/%{version}/inform7-ide-%{version}.tar.xz
-Source1: https://github.com/ganelson/inweb/archive/refs/heads/%{inweb_commit}.zip
-Source2: https://github.com/ganelson/intest/archive/refs/heads/%{intest_commit}.zip
-Source3: https://github.com/ganelson/inform/archive/refs/heads/%{inform_commit}.zip
+Source1: https://github.com/ganelson/inweb/archive/refs/tags/%{inweb_ref}#/ganelson-inweb-%{inweb_ref}-0-g%{inweb_short_sha}.tar.gz
+Source2: https://github.com/ganelson/intest/archive/refs/tags/%{intest_ref}#/ganelson-intest-%{intest_ref}-0-g%{intest_short_sha}.tar.gz
+Source3: https://github.com/ganelson/inform/archive/refs/tags/%{inform_ref}#/ganelson-inform-%{inform_ref}-0-g%{inform_short_sha}.tar.gz
 
 # Build requirements:
 BuildRequires: meson >= 0.56
@@ -53,9 +56,9 @@ games, to art pieces, which have won numerous awards and competitions.
 %define pkglibexecdir %{_libexecdir}/%{name}
 
 %prep
-rm -rf inweb inweb-*
-rm -rf intest intest-*
-rm -rf inform inform-*
+rm -rf inweb ganelson-inweb-%{inweb_short_sha}
+rm -rf intest ganelson-intest-%{intest_short_sha}
+rm -rf inform ganelson-inform-%{inform_short_sha}
 %setup -b 1
 %setup -b 2
 %setup -b 3
@@ -63,9 +66,9 @@ rm -rf inform inform-*
 sed -e 's/%{name}/%{name}-%{version}/g' build-aux/make-integration-settings.mk \
     > ../make-integration-settings.mk
 cd ..
-mv inweb-%{inweb_commit} inweb
-mv intest-%{intest_commit} intest
-mv inform-%{inform_commit} inform
+mv ganelson-inweb-%{inweb_short_sha} inweb
+mv ganelson-intest-%{intest_short_sha} intest
+mv ganelson-inform-%{inform_short_sha} inform
 sed -i -e 's/%{name}/%{name}-%{version}/g' \
     inform/resources/Documentation/indoc-instructions.txt
 
@@ -128,37 +131,21 @@ fi
 %{pkgdatadir}/HTML/*.html
 %{pkgdatadir}/HTML/*.js
 %{pkgdatadir}/HTML/xrefs.txt
-%{pkgdatadir}/Inter/BasicInformExtrasKit/Contents.w
-%{pkgdatadir}/Inter/BasicInformExtrasKit/kit_metadata.txt
-%{pkgdatadir}/Inter/BasicInformExtrasKit/arch-*.interb
-%{pkgdatadir}/Inter/BasicInformExtrasKit/Sections/*.i6t
-%{pkgdatadir}/Inter/BasicInformKit/Contents.w
-%{pkgdatadir}/Inter/BasicInformKit/kit_metadata.txt
-%{pkgdatadir}/Inter/BasicInformKit/arch-*.interb
-%{pkgdatadir}/Inter/BasicInformKit/Sections/*.i6t
-%{pkgdatadir}/Inter/BasicInformKit/kinds/*.neptune
-%{pkgdatadir}/Inter/CommandParserKit/Contents.w
-%{pkgdatadir}/Inter/CommandParserKit/kit_metadata.txt
-%{pkgdatadir}/Inter/CommandParserKit/arch-*.interb
-%{pkgdatadir}/Inter/CommandParserKit/Sections/*.i6t
-%{pkgdatadir}/Inter/CommandParserKit/kinds/*.neptune
-%{pkgdatadir}/Inter/EnglishLanguageKit/Contents.w
-%{pkgdatadir}/Inter/EnglishLanguageKit/kit_metadata.txt
-%{pkgdatadir}/Inter/EnglishLanguageKit/arch-*.interb
-%{pkgdatadir}/Inter/EnglishLanguageKit/Sections/*.i6t
-%{pkgdatadir}/Inter/WorldModelKit/Contents.w
-%{pkgdatadir}/Inter/WorldModelKit/kit_metadata.txt
-%{pkgdatadir}/Inter/WorldModelKit/arch-*.interb
-%{pkgdatadir}/Inter/WorldModelKit/Sections/*.i6t
-%{pkgdatadir}/Inter/WorldModelKit/kinds/*.neptune
+%{pkgdatadir}/Inter/*/Contents.w
+%{pkgdatadir}/Inter/*/kit_metadata.json
+%{pkgdatadir}/Inter/*/arch-*.interb
+%{pkgdatadir}/Inter/*/Sections/*.i6t
+%{pkgdatadir}/Inter/*/kinds/*.neptune
 %{pkgdatadir}/Languages/*/Index.txt
 %{pkgdatadir}/Languages/*/Syntax.preform
-%{pkgdatadir}/Languages/*/about.txt
 %{pkgdatadir}/Languages/*/flag.png
+%{pkgdatadir}/Languages/*/language_metadata.json
 %{pkgdatadir}/Miscellany/Basic.indext
 %{pkgdatadir}/Miscellany/Standard.indext
 %{pkgdatadir}/Miscellany/inform7_clib.c
 %{pkgdatadir}/Miscellany/inform7_clib.h
+%{pkgdatadir}/Miscellany/registry.jsonr
+%{pkgdatadir}/Miscellany/resource.jsonr
 %{pkgdatadir}/Miscellany/*.jpg
 %{pkgdatadir}/Miscellany/*.pdf
 %{pkgdatadir}/Pipelines/*.interpipeline

--- a/inform7-ide.spec
+++ b/inform7-ide.spec
@@ -78,7 +78,8 @@ cd ..
 bash inweb/scripts/first.sh linux
 bash intest/scripts/first.sh
 cd inform
-bash scripts/first.sh
+# Work around UB and/or miscompilation with -O2 -fstack-protector-strong
+CFLAGS='-O0 -fPIE' bash scripts/first.sh
 make forceintegration
 make retrospective
 cp -R retrospective ../%{name}-%{version}/


### PR DESCRIPTION
10.1.2 is a point release that includes a fix for not trying to rebuild internal files when they are mounted in Flatpak with an mtime of 0.