### PR TITLE
Rewrite some file operations to be asynchronous

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -37,6 +37,7 @@ add_project_arguments('-DLOCALEDIR="@0@"'.format(abs_localedir),
     '-DPACKAGE_LOCALE_DIR="@0@"'.format(abs_localedir),
     '-DPACKAGE_DATA_DIR="@0@"'.format(abs_datadir),
     '-DPACKAGE_LIBEXEC_DIR="@0@"'.format(abs_pkglibexecdir),
+    '-DG_LOG_DOMAIN="@0@"'.format(appname),
     language: 'c')
 
 top_include = include_directories('.')

--- a/src/actions.c
+++ b/src/actions.c
@@ -259,15 +259,14 @@ on_begin_print(GtkPrintOperation *print, GtkPrintContext *context,
 	g_autofree char *fontstring = i7_app_get_document_font_string(theapp);
 	gtk_source_print_compositor_set_body_font_name(compositor, fontstring);
 
-	/* Display a notification in the status bar while paginating */
-	i7_document_display_status_message(document, _("Paginating..."), PRINT_OPERATIONS);
+	/* This is unlikely to block the UI significantly, but set the status to
+	 * busy while it's happening just in case */
+	g_application_mark_busy(G_APPLICATION(theapp));
 	while(!gtk_source_print_compositor_paginate(compositor, context)) {
-		i7_document_display_progress_percentage(document, gtk_source_print_compositor_get_pagination_progress(compositor));
 		while(gtk_events_pending())
 			gtk_main_iteration();
 	}
-	i7_document_display_progress_percentage(document, 0.0);
-	i7_document_remove_status_message(document, PRINT_OPERATIONS);
+	g_application_unmark_busy(G_APPLICATION(theapp));
 
 	gtk_print_operation_set_n_pages(print, gtk_source_print_compositor_get_n_pages(compositor));
 }

--- a/src/document.h
+++ b/src/document.h
@@ -107,7 +107,6 @@ typedef void (*I7DocumentExtensionDownloadCallback)(gboolean success, const char
 
 /* Statusbar Contexts */
 #define FILE_OPERATIONS    "File"
-#define PRINT_OPERATIONS   "Print"
 #define SEARCH_OPERATIONS  "Search"
 #define COMPILE_OPERATIONS "Compile"
 #define INDEX_TABS         "Index"

--- a/src/document.h
+++ b/src/document.h
@@ -109,7 +109,6 @@ typedef void (*I7DocumentExtensionDownloadCallback)(gboolean success, const char
 #define FILE_OPERATIONS    "File"
 #define SEARCH_OPERATIONS  "Search"
 #define COMPILE_OPERATIONS "Compile"
-#define INDEX_TABS         "Index"
 
 GType i7_document_get_type(void) G_GNUC_CONST;
 GFile *i7_document_get_file(I7Document *self);

--- a/src/file.h
+++ b/src/file.h
@@ -17,6 +17,7 @@
 char *read_source_file(GFile *file);
 void set_source_text(GtkSourceBuffer *buffer, gchar *text);
 void delete_build_files(I7Story *story);
+void delete_index_files(I7Story *story);
 GFile *get_case_insensitive_extension(GFile *file);
 gboolean make_directory_unless_exists(GFile *file, GCancellable *cancellable, GError **error);
 gboolean file_exists_and_is_dir(GFile *file);

--- a/src/skein.h
+++ b/src/skein.h
@@ -8,6 +8,8 @@
 
 #include "config.h"
 
+#include <stdbool.h>
+
 #include <cairo.h>
 #include <glib.h>
 #include <glib-object.h>
@@ -75,7 +77,8 @@ void i7_skein_set_current_node(I7Skein *self, I7Node *node);
 gboolean i7_skein_is_node_in_current_thread(I7Skein *self, I7Node *node);
 I7Node *i7_skein_get_played_node(I7Skein *self);
 gboolean i7_skein_load(I7Skein *self, GFile *file, GError **error);
-gboolean i7_skein_save(I7Skein *self, GFile *file, GError **error);
+void i7_skein_save_async(I7Skein *self, GFile *file, int priority, GCancellable *cancel, GAsyncReadyCallback callback, void *data);
+bool i7_skein_save_finish(I7Skein *self, GAsyncResult *res, GError **error);
 gboolean i7_skein_import(I7Skein *self, GFile *file, GError **error);
 void i7_skein_reset(I7Skein *self, gboolean current);
 void i7_skein_draw(I7Skein *self, GooCanvas *canvas);

--- a/src/story-compile.c
+++ b/src/story-compile.c
@@ -264,7 +264,7 @@ ui_finish_i7_compiler(FinishI7Data *data)
 	}
 
 	/* Reload the Index in the background */
-	i7_story_reload_index_tabs(data->story, FALSE);
+	i7_story_reload_index_tabs(data->story);
 
 	return G_SOURCE_REMOVE;
 }

--- a/src/story-index.c
+++ b/src/story-index.c
@@ -58,11 +58,7 @@ check_and_load_idle(I7Story *story)
 
 /* Load all the correct files in the index tabs, if they exist */
 void
-i7_story_reload_index_tabs(I7Story *story, gboolean wait)
+i7_story_reload_index_tabs(I7Story *story)
 {
-	if(wait)
-		while(check_and_load_idle(story))
-			;
-	else
-		g_idle_add((GSourceFunc)check_and_load_idle, story);
+	g_idle_add((GSourceFunc)check_and_load_idle, story);
 }

--- a/src/story.c
+++ b/src/story.c
@@ -127,6 +127,7 @@ on_storywindow_delete_event(GtkWidget *window, GdkEvent *event)
 	GFile *file = i7_document_get_file(I7_DOCUMENT(window));
 	if(file) {
 		delete_build_files(I7_STORY(window));
+		delete_index_files(I7_STORY(window));
 		g_object_unref(file);
 	}
 
@@ -498,6 +499,7 @@ i7_story_save_as(I7Document *document, GFile *file)
 
 	/* Delete the build files from the project directory */
 	delete_build_files(self);
+	delete_index_files(self);
 
 	/* Set the folder icon to be the Inform 7 project icon */
 	file_set_custom_icon(file, "com.inform7.IDE.application-x-inform");

--- a/src/story.c
+++ b/src/story.c
@@ -1344,7 +1344,7 @@ i7_story_open(I7Story *self, GFile *input_file)
     g_object_notify(object, "basic-inform");
 
 	/* Load index tabs if they exist */
-	i7_story_reload_index_tabs(self, FALSE);
+	i7_story_reload_index_tabs(self);
 
 	/* Check if the story uses the old-style name for the Materials folder, and if
 	so, quietly rename it */

--- a/src/story.c
+++ b/src/story.c
@@ -121,7 +121,7 @@ on_storywindow_delete_event(GtkWidget *window, GdkEvent *event)
 
 	save_storywindow_size(I7_STORY(window));
 
-	gtk_widget_destroy(I7_STORY(window)->notes_window);
+	gtk_widget_hide(I7_STORY(window)->notes_window);
 	i7_story_stop_running_game(I7_STORY(window));
 
 	GFile *file = i7_document_get_file(I7_DOCUMENT(window));
@@ -935,6 +935,10 @@ i7_story_init(I7Story *self)
 	LOAD_WIDGET(skein_trim_popover);
 	LOAD_WIDGET(skein_trim_slider);
 
+	/* Hold a reference to the notes window so the pointer doesn't become
+	 * invalid when the window is closed. */
+	g_object_ref(self->notes_window);
+
 	/* Build the Open Extensions menu */
 	i7_app_update_extensions_menu(theapp);
 
@@ -1051,6 +1055,7 @@ i7_story_finalize(GObject *object)
 	g_clear_pointer(&priv->manifest, plist_free);
     g_clear_object(&self->skein_spacing_popover);
     g_clear_object(&self->skein_trim_popover);
+	g_clear_object(&self->notes_window);
 	G_OBJECT_CLASS(i7_story_parent_class)->finalize(object);
 }
 

--- a/src/story.h
+++ b/src/story.h
@@ -110,7 +110,7 @@ void i7_story_remove_debug_tabs(I7Story *story);
 GtkSourceBuffer *create_inform6_source_buffer(void);
 
 /* Index pane, story-index.c */
-void i7_story_reload_index_tabs(I7Story *self, gboolean wait);
+void i7_story_reload_index_tabs(I7Story *self);
 
 /* Settings pane, story-settings.c */
 plist_t create_default_settings(void);


### PR DESCRIPTION
It's better, when doing file operations that the UI doesn't need to wait on (such as cleaning out old build files, or saving the project) to use asynchronous operations that don't block the UI. Sadly these are a lot more tedious to write in C, but they allow us to make a less use of the progress meter in the status bar, which wastes precious vertical space and is an outdated UI pattern that I'd eventually like to remove altogether.