### PR TITLE
styles: Specify color of cursor to be text color

### DIFF
--- a/data/styles/dark.xml
+++ b/data/styles/dark.xml
@@ -29,6 +29,8 @@ SPDX-FileCopyrightText: 2022 Philip Chimento <philip.chimento@gmail.com>
   <style name="bracket-match"     bold="true"/>
   <style name="bracket-mismatch"  foreground="source_paper" background="error" bold="true"/>
   <style name="search-match"      foreground="main_text" background="highlight"/>
+  <style name="cursor"            foreground="main_text"/>
+  <style name="secondary-cursor"  foreground="main_text"/>
 
   <!-- I7 core types -->
   <style name="inform7:plain"     foreground="main_text" background="source_paper"/>

--- a/data/styles/light.xml
+++ b/data/styles/light.xml
@@ -29,6 +29,8 @@ SPDX-FileCopyrightText: 2022 Philip Chimento <philip.chimento@gmail.com>
   <style name="bracket-match"     bold="true"/>
   <style name="bracket-mismatch"  foreground="source_paper" background="error" bold="true"/>
   <style name="search-match"      foreground="main_text" background="highlight"/>
+  <style name="cursor"            foreground="main_text"/>
+  <style name="secondary-cursor"  foreground="main_text"/>
 
   <!-- I7 core types -->
   <style name="inform7:plain"     foreground="main_text" background="source_paper"/>

--- a/data/styles/sevenseas.xml
+++ b/data/styles/sevenseas.xml
@@ -29,6 +29,8 @@ SPDX-FileCopyrightText: 2022 Philip Chimento <philip.chimento@gmail.com>
   <style name="bracket-match"     bold="true"/>
   <style name="bracket-mismatch"  foreground="source_paper" background="error" bold="true"/>
   <style name="search-match"      foreground="main_text" background="highlight"/>
+  <style name="cursor"            foreground="main_text"/>
+  <style name="secondary-cursor"  foreground="main_text"/>
 
   <!-- I7 core types -->
   <style name="inform7:plain"     foreground="main_text" background="source_paper"/>

--- a/data/styles/traditional.xml
+++ b/data/styles/traditional.xml
@@ -34,6 +34,8 @@ SPDX-FileCopyrightText: 2008, 2022 Philip Chimento <philip.chimento@gmail.com>
   <style name="bracket-match"     bold="true"/>
   <style name="bracket-mismatch"  foreground="background" background="error" bold="true"/>
   <style name="search-match"      foreground="text" background="highlight"/>
+  <style name="cursor"           foreground="text"/>
+  <style name="secondary-cursor" foreground="text"/>
 
   <!-- I7 core types -->
   <style name="inform7:plain"     foreground="text" background="background"/>


### PR DESCRIPTION
Without specifying the cursor color, if the text views had a light theme on a dark GTK theme, or vice versa, the cursor would get the color of the GTK theme and therefore be invisible or almost invisible.

Closes: https://inform7.atlassian.net/browse/I7-2358