### PR TITLE
Add "added-nest" configuration option

### DIFF
--- a/com.inform7.IDE.gschema.xml
+++ b/com.inform7.IDE.gschema.xml
@@ -158,6 +158,15 @@
       standard.</description>
     </key>
 
+    <key name="added-nest" type="s">
+      <default>''</default>
+      <summary>Additional search directory for extensions for Inform 7 projects</summary>
+      <description>This should be the parent directory of a directory called "Extensions".
+      If present, the Inform 7 compiler will search this to find additional extensions
+      when compiling all Inform 7 projects. Useful when developing Inform 7 extensions.
+      If left blank, do not check any additional directory.</description>
+    </key>
+
     <key name="clean-build-files" type="b">
       <default>true</default>
       <summary>Clean build files from projects before closing</summary>

--- a/src/app-retrospective.c
+++ b/src/app-retrospective.c
@@ -13,6 +13,7 @@
 #include "app.h"
 #include "app-retrospective.h"
 #include "story.h"
+#include "configfile.h"
 
 typedef enum {
 	INFORM_10_1,
@@ -179,6 +180,16 @@ i7_app_get_inform_command_line(I7App *self, const char *version_id, int format, 
 	else
 		g_ptr_array_add(builder, g_strdup("-internal"));
 	g_ptr_array_add(builder, internal_path);
+
+	GSettings *prefs = i7_app_get_prefs(self);
+	g_autofree char *added_nest_dir = g_settings_get_string(prefs, PREFS_ADDED_NEST);
+	if (added_nest_dir[0] != '\0') {
+		if (style == INFORM_9_1 || style == INFORM_9_2)
+			g_ptr_array_add(builder, g_strdup("-external"));
+		else if (style == INFORM_10_1)
+			g_ptr_array_add(builder, g_strdup("-nest"));
+		g_ptr_array_add(builder, g_strdup(added_nest_dir));
+	}
 
 	g_ptr_array_add(builder, g_strdup(get_inform_format_arg(style, (I7StoryFormat)format, debug)));
 

--- a/src/configfile.h
+++ b/src/configfile.h
@@ -65,6 +65,7 @@ typedef enum {
 #define PREFS_AUTO_INDENT          "auto-indent"
 #define PREFS_AUTO_NUMBER          "auto-number"
 #define PREFS_INTERPRETER          "interpreter"
+#define PREFS_ADDED_NEST           "added-nest"
 #define PREFS_CLEAN_BUILD_FILES    "clean-build-files"
 #define PREFS_CLEAN_INDEX_FILES    "clean-index-files"
 #define PREFS_SHOW_DEBUG_LOG       "show-debug-log"

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -92,6 +92,7 @@ struct _I7PrefsWindow {
 	GtkSwitch *enable_highlighting;
 	HdyPreferencesGroup *font_group;
 	HdyComboRow *glulx_interpreter;
+	GtkEntry *added_nest;
 	GtkButton *restore_default_font;
 	GtkSwitch *show_debug_tabs;
 	GtkSpinButton *tab_width;
@@ -519,6 +520,7 @@ i7_prefs_window_class_init(I7PrefsWindowClass *klass)
 	gtk_widget_class_bind_template_child(widget_class, I7PrefsWindow, enable_highlighting);
 	gtk_widget_class_bind_template_child(widget_class, I7PrefsWindow, font_group);
 	gtk_widget_class_bind_template_child(widget_class, I7PrefsWindow, glulx_interpreter);
+	gtk_widget_class_bind_template_child(widget_class, I7PrefsWindow, added_nest);
 	gtk_widget_class_bind_template_child(widget_class, I7PrefsWindow, restore_default_font);
 	gtk_widget_class_bind_template_child(widget_class, I7PrefsWindow, show_debug_tabs);
 	gtk_widget_class_bind_template_child(widget_class, I7PrefsWindow, source_example);
@@ -571,6 +573,7 @@ i7_prefs_window_bind_settings(I7PrefsWindow *self, GSettings *prefs)
 	BIND(PREFS_TAB_WIDTH, tab_width, "value");
 	BIND_COMBO_BOX(PREFS_DOCS_FONT_SIZE, docs_font_size, font_size_enum);
 	BIND_COMBO_BOX(PREFS_INTERPRETER, glulx_interpreter, interpreter_enum);
+	BIND(PREFS_ADDED_NEST, added_nest, "text");
 #undef BIND
 #undef BIND_COMBO_BOX
 	g_settings_bind_with_mapping(prefs, PREFS_FONT_SET,

--- a/src/ui/prefs.ui
+++ b/src/ui/prefs.ui
@@ -388,6 +388,34 @@ a white jersey	1975	"best cyclist aged 25 or less"</property>
             </child>
           </object>
         </child>
+        <child>
+          <object class="HdyPreferencesGroup">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="title" translatable="yes">Advanced compiler options</property>
+            <child>
+              <object class="HdyActionRow">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="activatable">False</property>
+                <property name="selectable">False</property>
+                <property name="title" translatable="yes">Additional extensions folder</property>
+                <property name="subtitle" translatable="yes">This option is intended only for advanced users of Inform 7. It should be the full path to a folder containing a folder named "Extensions". The compiler will search this folder for extensions (in addition to the usual locations) when compiling all projects. This can be useful for testing a work-in-progress extension.</property>
+                <property name="subtitle-lines">8</property>
+                <child>
+                  <object class="GtkEntry" id="added_nest">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="valign">center</property>
+                    <property name="hexpand">True</property>
+                    <property name="primary-icon-activatable">False</property>
+                    <property name="secondary-icon-activatable">False</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
       </object>
     </child>
   </template>


### PR DESCRIPTION
This allows my workflow when developing Inform 7 extensions to work again with the upcoming Inform version 11.

Inform 11 is eliminating the master extensions directory, the census, etc., in favor of storing extensions primarily in the game.materials directory for each game.

However,  I have a directory for extensions under development, and I want to add them into a large number of different games at once, which I then compile, test, and run.  (After each time I edit the extension.) There is a command-line option --nest in Inform 11 to allow me to do this.  This patch allows me to invoke that command-line option through the IDE automatically.

This version works.  It doesn't break anything for people not using this advanced-users-only option.  It fixes things for me.

The behavior of this option should arguably be cued off a new INFORM_11 version code.  Unfortunately doing that seems to depend on updates to the core inform respository to put an INFORM_10_1 into the "retrospective" directory, which is beyond my abilities right now.  However, should that happen, the version of this patch which depends on an INFORM_11 version code is also available, in my added-nest-11 branch.

Thank you for considering this.