### PR TITLE
Fix deprecated build scripts and instructions

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -20,8 +20,8 @@ You'll need to work out yourself which packages to install, but the
 
 ```bash
 sudo apt-get update
-sudo apt-get upgrade -y
-sudo apt-get install -y \
+sudo apt-get upgrade --assume-yes --show-progress
+sudo apt-get install --assume-yes --show-progress \
     libcanberra-gtk3-module dbus-x11 ninja-build meson \
     libxml2-dev pkg-config libglib2.0-dev libgoocanvas-2.0-dev \
     libwebkit2gtk-4.1-dev libgtksourceview-4-dev libgspell-1-dev \
@@ -126,7 +126,7 @@ Note that this will **overwrite** any existing installation of the app
 if you installed a DEB or RPM package.
 
 ```bash
-meson _build -Dprefix=/usr
+meson setup _build -Dprefix=/usr
 ninja -C _build
 sudo ninja -C _build install
 ```

--- a/meson.build
+++ b/meson.build
@@ -6,6 +6,7 @@ app_version = meson.project_version()
 
 gnome = import('gnome')
 i18n = import('i18n')
+fs = import('fs')
 
 cc = meson.get_compiler('c')
 
@@ -146,8 +147,12 @@ retrospective_data_dirs = {
 foreach build, internal_dirs : retrospective_data_dirs
     retrospectivedir = pkgdatadir / 'retrospective' / build
     foreach internal_dir : internal_dirs
-        install_subdir('retrospective/@0@/@1@'.format(build, internal_dir),
-            install_dir: retrospectivedir)
+        isd = 'retrospective/@0@/@1@'.format(build, internal_dir)
+	if fs.exists(isd)
+            install_subdir(isd, install_dir: retrospectivedir)
+        else
+            install_emptydir(retrospectivedir)
+        endif
     endforeach
 endforeach
 


### PR DESCRIPTION
This PR adds user-friendly CLI options for apt-get and corrects deprecated meson commands and code in the meson build scripts. Fixes all deprecation warnings while preserving the existing behaviours.