### PR TITLE
meson.build: Point to BUILD.md

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -17,7 +17,7 @@ inform7 = find_program('intools/inform7', required: false)
 if not inform7.found()
     error('''I couldn't find the Inform
     compiler or its data files. You must first build the Inform compiler. See
-    INSTALL.md for instructions.''')
+    BUILD.md for instructions.''')
 endif
 
 ### DEFINE VARIABLES ###########################################################


### PR DESCRIPTION
The error message for a missing 'inform7' directed the user to read INSTALL.md, which since 1928b13 no longer contains anything of relevance. Change to BUILD.md, which now does.